### PR TITLE
fix: variable content

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ module.exports = (eleventyConfig, userOptions = {}) => {
                     link.setAttribute("rel", options.rel);
                 }
             });
-            const content = root.toString();
-            return options.includeDoctype ? `<!DOCTYPE html>${content}` : content;
+            const newContent = root.toString();
+            return options.includeDoctype ? `<!DOCTYPE html>${newContent}` : newContent;
         }
         return content;
     })


### PR DESCRIPTION
Why: `content` was already used for the original content.
The original 1.1.1 code gave error when running 11ty